### PR TITLE
Handle errors not instance of Boom

### DIFF
--- a/src/middleware/error.js
+++ b/src/middleware/error.js
@@ -12,8 +12,14 @@ const handler = async (ctx, next) => {
 
       return;
     }
-    // TODO: Handle error that are not instance of `boom`
+    
+    if (error instanceof Error) {
+      ctx.body = error.message;
+      ctx.status = error.statusCode || 500;
 
+      return;
+    }
+    
     throw error;
   }
 };


### PR DESCRIPTION
All errors are instance of the base Error class and contain a message. Mapping the message to body and status code if defined handles all possible error cases.